### PR TITLE
Fix Sdk constrain - support '>=3.0.0 <4.0.0' now 

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -404,5 +404,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.3.4 <4.0.0"
+  dart: ">=3.3.0-279.1.beta <4.0.0"
   flutter: ">=3.16.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,3 +24,4 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: "Demonstrates how to use the app_badge_plus plugin."
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: '>=3.3.4 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.0.0
 homepage: https://github.com/windows7lake/app_badge_plus
 
 environment:
-  sdk: '>=3.3.4 <4.0.0'
-  flutter: '>=3.3.0'
+  sdk: '>=3.0.0 <4.0.0'
+ 
 
 dependencies:
   flutter:


### PR DESCRIPTION
I adjusted the sdk constrain to support lower version of flutter 

```dart
environment:
  sdk: '>=3.0.0 <4.0.0'
```
