### PR TITLE
Add permission to AndroidManifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ touch & hold the app icon to reveal the notifications, along with any app shortc
 
 https://developer.android.com/develop/ui/views/notifications/badges
 
-Starting With Android13 (API level 26), notification runtime permission should be requested before setting the app badge.
+Starting With Android13 (API level 33), notification runtime permission should be requested before setting the app badge.
 
 Add the following permissions to `AndroidManifest.xml` according to the system you need to support:
 ```xml

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,26 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="me.liolin.app_badge_plus">
+    package="me.liolin.app_badge_plus">
+
+    <!-- Samsung -->
+    <uses-permission android:name="com.sec.android.provider.badge.permission.READ" />
+    <uses-permission android:name="com.sec.android.provider.badge.permission.WRITE" />
+
+    <!-- HTC -->
+    <uses-permission android:name="com.htc.launcher.permission.READ_SETTINGS" />
+    <uses-permission android:name="com.htc.launcher.permission.UPDATE_SHORTCUT" />
+
+    <!-- Sony -->
+    <uses-permission android:name="com.sonyericsson.home.permission.BROADCAST_BADGE" />
+    <uses-permission android:name="com.sonymobile.home.permission.PROVIDER_INSERT_BADGE" />
+
+    <!-- Apex -->
+    <uses-permission android:name="com.anddoes.launcher.permission.UPDATE_COUNT" />
+
+    <!-- Solid -->
+    <uses-permission android:name="com.majeur.launcher.permission.UPDATE_BADGE" />
+
+    <!-- Huawei -->
+    <uses-permission android:name="com.huawei.android.launcher.permission.CHANGE_BADGE" />
+    <uses-permission android:name="com.huawei.android.launcher.permission.READ_SETTINGS" />
+    <uses-permission android:name="com.huawei.android.launcher.permission.WRITE_SETTINGS" />
 </manifest>


### PR DESCRIPTION
Simplify integration steps and avoid manually adding permissions