### PR TITLE
Fix Gradle/Kotlin compatibility warning for Flutter built-in Kotlin migration (KGP deprecation)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,34 +1,7 @@
 group = 'me.liolin.app_badge_plus'
 version = '1.0-SNAPSHOT'
 
-buildscript {
-    ext.kotlin_version = '2.3.0'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 apply plugin: 'com.android.library'
-
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-def builtInKotlin = agpMajor >= 9 &&
-    project.findProperty('android.builtInKotlin')?.toString() != 'false'
-if (!builtInKotlin) {
-    apply plugin: 'kotlin-android'
-}
 
 android {
     namespace = 'me.liolin.app_badge_plus'

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -84,9 +84,9 @@ class _MyAppState extends State<MyApp> {
           if (value.isGranted) {
             isNotificationAllowed = true;
             setState(() {});
-            print('Permission is granted');
+            debugPrint('Permission is granted');
           } else {
-            print('Permission is not granted');
+            debugPrint('Permission is not granted');
             isNotificationAllowed = false;
             setState(() {});
           }


### PR DESCRIPTION
## Changes

- Removed legacy usage of `kotlin-android` Gradle plugin where required
- Updated Android Gradle configuration to align with Flutter’s built-in Kotlin migration
- Ensured compatibility with Flutter 3.44+ and Android Gradle Plugin 9+
- Fixed build warnings related to Kotlin Gradle Plugin (KGP) deprecation
- Updated `example/` project to build and run without Kotlin-related warnings

## Why this change is needed

Flutter 3.44+ introduces **built-in Kotlin support** and deprecates the legacy use of the Kotlin Gradle Plugin (KGP) via `kotlin-android`.

Plugins that still apply KGP will trigger warnings indicating future build failures once support is fully removed in Flutter.

This update ensures the plugin is compatible with the new Flutter Android build system.

## Testing

- Verified `flutter analyze` runs without issues
- Successfully built and ran the `example/` app on Android and iOS real device
- Confirmed no Kotlin Gradle Plugin warnings during build
- Tested with Flutter 3.44+

## Impact

This is a build system / compatibility update only.
No runtime or API behavior has been changed.